### PR TITLE
update gh actions that use node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         mv Package.swift.next Package.swift
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: '1.19.x'
 


### PR DESCRIPTION
I'm assuming setup-go is (or was at one point) a requirement for `ziti-ci`? Is that (still) true?