### PR TITLE
enable tlsuv logging (#286)

### DIFF
--- a/lib/Ziti.swift
+++ b/lib/Ziti.swift
@@ -139,6 +139,7 @@ import CZitiPrivate
         loop = UnsafeMutablePointer<uv_loop_t>.allocate(capacity: 1)
         loop.initialize(to: uv_loop_t())
         uv_loop_init(loop)
+        ziti_log_init_wrapper(loop)
         super.init()
         initOpsHandle()
     }
@@ -158,6 +159,7 @@ import CZitiPrivate
         loop = UnsafeMutablePointer<uv_loop_t>.allocate(capacity: 1)
         loop.initialize(to: uv_loop_t())
         uv_loop_init(loop)
+        ziti_log_init_wrapper(loop)
         super.init()
         initOpsHandle()
     }
@@ -172,6 +174,7 @@ import CZitiPrivate
         loop = UnsafeMutablePointer<uv_loop_t>.allocate(capacity: 1)
         loop.initialize(to: uv_loop_t())
         uv_loop_init(loop)
+        ziti_log_init_wrapper(loop)
         super.init()
         initOpsHandle()
     }

--- a/lib/ZitiLog.swift
+++ b/lib/ZitiLog.swift
@@ -91,8 +91,8 @@ public class ZitiLog {
     ///
     /// - Parameters:
     ///     - level: only log messages at this level or higher severity
-    public class func setLogLevel(_ level:LogLevel) {
-        ziti_log_set_level(level.rawValue, nil)
+    public class func setLogLevel(_ level:LogLevel, module:String? = nil) {
+        ziti_log_set_level(level.rawValue, module)
         ziti_tunnel_set_log_level(level.rawValue)
     }
     


### PR DESCRIPTION
* allow setting log level for specific modules

* initialize ziti-sdk-c logger early to prevent init from overwriting previously set tlsuv log level